### PR TITLE
Exclude non-root package file contents from NOTICE generation

### DIFF
--- a/business/noticeService.js
+++ b/business/noticeService.js
@@ -87,7 +87,7 @@ class NoticeService {
     if (!definition.files) return ''
     const texts = await Promise.all(
       definition.files
-        .filter(file => file.token && file.natures && file.natures.includes('license'))
+        .filter(file => file.token && file.natures && file.natures.includes('license') && file.path && (file.path.indexOf('/') === -1))
         .map(file => this.attachmentStore.get(file.token))
     )
     return texts.join('\n\n')

--- a/test/business/noticeServiceTest.js
+++ b/test/business/noticeServiceTest.js
@@ -51,6 +51,36 @@ describe('Notice Service', () => {
     expect(notice.content).to.eq('** test; version 1.0.0 -- \n\n%%%This is the attachment%%%')
   })
 
+  it('includes license only for top-level files in a package', async () => {
+    const { service, coordinates } = setup(
+      {
+        'npm/npmjs/-/tested/1.0.0': {
+          coordinates: { name: 'tested', revision: '1.0.0' },
+          licensed: { declared: 'MIT' },
+          files: [{ path: 'LICENSE', token: 'abcd', natures: ['license'] }],
+          described: { tools: ['clearlydefined/1.0.0'] }
+
+        },
+        'npm/npmjs/-/tested/2.0.0': {
+          coordinates: { name: 'tested', revision: '2.0.0' },
+          licensed: { declared: 'MIT' },
+          files: [
+            { path: 'some/other/LICENSE', token: 'efgh', natures: ['license'] },
+            { path: 'LICENSE', token: 'ijkl', natures: ['license'] }
+          ],
+          described: { tools: ['clearlydefined/1.0.0'] }
+        },
+      },
+      {
+        abcd: '%%%This is the attachment%%%',
+        efgh: '%%%This should not be included!%%%',
+        ijkl: '%%%This should be included!%%%',
+      }
+    )
+    const notice = await service.generate(coordinates)
+    expect(notice.content).to.eq('** tested; version 2.0.0 -- \n\n%%%This should be included!%%%\n\n------\n\n** tested; version 1.0.0 -- \n\n%%%This is the attachment%%%')
+  })
+
   it('renders with custom template', async () => {
     const { service, coordinates } = setup({
       'npm/npmjs/-/test/1.0.0': {


### PR DESCRIPTION
Some packages have too many files that would be included in the notice.
Example: https://clearlydefined.io/definitions/git/github/tensorflow/tensorflow/3ffdb91f122f556a74a6e1efd2469bfe1063cb5c.

This adds a simple filter to exclude anything that's not at the root of the repository (any files with `/` in the path).